### PR TITLE
Fix the scatter chart data set colour lookup

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/ScatterChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/ScatterChartRenderer.java
@@ -84,7 +84,7 @@ public class ScatterChartRenderer extends LineScatterCandleRadarRenderer {
                     || !viewPortHandler.isInBoundsY(mPixelBuffer[1]))
                 continue;
 
-            mRenderPaint.setColor(dataSet.getColor(i / 2));
+            mRenderPaint.setColor(dataSet.getColor(i));
             renderer.renderShape(
                     c, dataSet, mViewPortHandler,
                     mPixelBuffer[0], mPixelBuffer[1],


### PR DESCRIPTION
## PR Checklist:
- [ ] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
Update to the ScatterChartRenderer to resolve an issue where the data set colours were being set incorrectly.

The data set colour lookup now uses the data set index rather than index/2.

Scatter chart graphs using different colours are affected by this bug, and with this fix, the data set point colours will be rendered as intended.
